### PR TITLE
Catch missing identifiers resulting in KeyError

### DIFF
--- a/main.py
+++ b/main.py
@@ -214,10 +214,19 @@ def download_access_stats_new(file_path: str, release_date: str, username: str, 
 
     all_results = []
     for item in response_json['Report_Items']:
-        proprietary_id = item['Item_ID']['Proprietary']
-        uri = item['Item_ID']['URI']
-        doi = item['Item_ID']['DOI']
-        isbn = item['Item_ID']['ISBN']
+        # Get item IDs if they are given
+        ids = {'Proprietary': None, 'URI': None, 'DOI': None, 'ISBN': None}
+        for id_name in ids:
+            try:
+                id_value = item['Item_ID'][id_name]
+                ids[id_name] = id_value
+            except KeyError:
+                pass
+        proprietary_id = ids['Proprietary']
+        uri = ids['URI']
+        doi = ids['DOI']
+        isbn = ids['ISBN']
+
         book_title = item['Item']
         publisher = item['Publisher']
         for client in item['Performance']:

--- a/tests/fixtures/download_2020_04.json
+++ b/tests/fixtures/download_2020_04.json
@@ -40,7 +40,6 @@
       "Item_ID": {
         "Proprietary": "irus:8892521",
         "URI": "http://library.oapen.org/handle/83.192.71036/91737",
-        "DOI": "17.94184/192.9617439216201",
         "ISBN": "9617439216201"
       },
       "Performance": [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,7 +48,7 @@ class TestCloudFunction(unittest.TestCase):
         self.download_path_old = test_fixtures_path('download_2020_03.tsv')
         self.download_hash_old = '361294f7'
         self.download_path_new = test_fixtures_path('download_2020_04.json')
-        self.download_hash_new = '4e44dfbf'
+        self.download_hash_new = 'b13ea0a6'
 
     @patch('main.download_geoip')
     @patch('main.geoip2.database.Reader')


### PR DESCRIPTION
Not all identifiers are available for some items (e.g. DOI) in the 'new' platform, resulting in a KeyError.